### PR TITLE
build: disable searchable options

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -52,4 +52,8 @@ tasks {
     publishPlugin {
         token.set(System.getenv("PUBLISH_TOKEN"))
     }
+
+    buildSearchableOptions {
+        enabled = false
+    }
 }


### PR DESCRIPTION
- disables the building of searchable options, which slows down the
build process and is unnecessary when custom settings are not being
provided