### PR TITLE
feat: inspection and toggling support

### DIFF
--- a/src/main/kotlin/me/benmelz/jetbrains/plugins/hamllint/HamlLintExternalAnnotator.kt
+++ b/src/main/kotlin/me/benmelz/jetbrains/plugins/hamllint/HamlLintExternalAnnotator.kt
@@ -6,10 +6,14 @@ import com.intellij.lang.annotation.HighlightSeverity
 import com.intellij.openapi.editor.Document
 import com.intellij.openapi.roots.ProjectFileIndex
 import com.intellij.openapi.util.TextRange
+import com.intellij.profile.codeInspection.ProjectInspectionProfileManager
 import com.intellij.psi.PsiFile
 
 class HamlLintExternalAnnotator : ExternalAnnotator<HamlLintExternalAnnotatorInfo, List<HamlLintOffense>>() {
     override fun collectInformation(file: PsiFile): HamlLintExternalAnnotatorInfo? {
+        val inspectionProfile = ProjectInspectionProfileManager.getInstance(file.project).currentProfile
+        val inspectionToolDisplayKey = inspectionProfile.getInspectionTool("HamlLint", file)?.displayKey
+        if (!inspectionProfile.isToolEnabled(inspectionToolDisplayKey, file)) return null
         val fileText = file.viewProvider.document.charsSequence
         val contentRoot = ProjectFileIndex
             .getInstance(file.project)

--- a/src/main/kotlin/me/benmelz/jetbrains/plugins/hamllint/HamlLintInspection.kt
+++ b/src/main/kotlin/me/benmelz/jetbrains/plugins/hamllint/HamlLintInspection.kt
@@ -1,0 +1,14 @@
+package me.benmelz.jetbrains.plugins.hamllint
+
+import com.intellij.codeInspection.ExternalAnnotatorInspectionVisitor
+import com.intellij.codeInspection.LocalInspectionTool
+import com.intellij.codeInspection.ProblemsHolder
+import com.intellij.psi.PsiElementVisitor
+
+class HamlLintInspection : LocalInspectionTool() {
+    override fun buildVisitor(holder: ProblemsHolder, isOnTheFly: Boolean): PsiElementVisitor {
+        return ExternalAnnotatorInspectionVisitor(holder, HamlLintExternalAnnotator(), isOnTheFly)
+    }
+
+    override fun showDefaultConfigurationOptions(): Boolean = false
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -28,6 +28,11 @@
     <!-- Extension points defined by the plugin.
          Read more: https://plugins.jetbrains.com/docs/intellij/plugin-extension-points.html -->
     <extensions defaultExtensionNs="com.intellij">
+        <localInspection language="Haml"
+                         implementationClass="me.benmelz.jetbrains.plugins.hamllint.HamlLintInspection"
+                         groupName="Haml"
+                         displayName="HamlLint"
+                         enabledByDefault="true" />
         <externalAnnotator language="Haml"
                            implementationClass="me.benmelz.jetbrains.plugins.hamllint.HamlLintExternalAnnotator"/>
     </extensions>

--- a/src/main/resources/inspectionDescriptions/HamlLint.html
+++ b/src/main/resources/inspectionDescriptions/HamlLint.html
@@ -1,0 +1,6 @@
+<html>
+<body>
+Reports issues from the <a href="https://github.com/sds/haml-lint">HamlLint</a>. linter.
+Requires the haml-lint gem to be installed in the project SDK.
+</body>
+</html>


### PR DESCRIPTION
- adds a runnable inspection tool that is able to run the external
annotator on demand
- adjusts the external annotator to check if the inspection is enabled
before running, aborting if it isn't

Closes #3 