### PR TITLE
doc: expand readme and plugin description

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,30 @@
 # haml-lint-intellij-plugin
 
 [`haml-lint`](https://github.com/sds/haml-lint) annotations for [Jetbrains IDEs](https://www.jetbrains.com).
+
+## Installation & Usage
+
+Installation and usage instructions are hosted on the
+[Jetbrains Marketplace](https://plugins.jetbrains.com/plugin/21585-hamllint).
+
+## Contributing
+
+Issues and pull requests are welcome on GitHub.
+
+### Development
+
+This plugin is written using Kotlin on the
+[Intellij Platform SDK](https://plugins.jetbrains.com/docs/intellij/welcome.html). Gradle manages all project
+dependencies and a gradle wrapper is bundled within the repository, so the only real system requirement is a Java JDK
+matching the targeted version in
+[`build.gradle.kts`](https://github.com/benmelz/haml-lint-intellij-plugin/blob/main/build.gradle.kts). `ktlint` is used
+to enforce code style and `semantic-release` is used to release packages/publish to the marketplace.
+
+```bash
+./gradlew check       # builds the plugin, runs linters and tests
+./gradlew runIde      # builds the plugin, starts up an IDE for manual testing
+```
+
+## License
+
+This plugin available as open source under the terms of the [MIT License](https://opensource.org/licenses/MIT).

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -15,12 +15,15 @@
          Guidelines: https://plugins.jetbrains.com/docs/marketplace/plugin-overview-page.html#plugin-description -->
     <description><![CDATA[
     <p>
-      Provides realtime annotation of <code><a href="https://github.com/sds/haml-lint">haml-lint</a></code> offenses.
+      Provides realtime inspection of <code><a href="https://github.com/sds/haml-lint">haml-lint</a></code> offenses.
     </p>
     <p>
-      No configuration or setup is necessary from the IDE. As long as <code>haml-lint</code> is included in your
-      project's <code>Gemfile</code>, the plugin will automatically annotate <code>.haml</code> files for you while you
-      have them open.
+      No setup is necessary from the IDE. As long as <code>haml-lint</code> is included in your project's
+      <code>Gemfile</code>, the plugin will automatically annotate <code>.haml</code> files for you while you have
+      them open.
+    </p>
+    <p>
+      The inspector can be turned on/off using the inspections menu (Haml -> HamlLint).
     </p>
     ]]></description>
 

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -14,10 +14,14 @@
          Simple HTML elements (text formatting, paragraphs, and lists) can be added inside of <![CDATA[ ]]> tag.
          Guidelines: https://plugins.jetbrains.com/docs/marketplace/plugin-overview-page.html#plugin-description -->
     <description><![CDATA[
-    Provides realtime annotation of <code><a href="https://github.com/sds/haml-lint">haml-lint</a></code> offenses.
-
-    No configuration or setup is necessary from the IDE. As long as haml-lint is included in your project's Gemfile, the
-    plugin will automatically annotate .haml files for you while you have them open.
+    <p>
+      Provides realtime annotation of <code><a href="https://github.com/sds/haml-lint">haml-lint</a></code> offenses.
+    </p>
+    <p>
+      No configuration or setup is necessary from the IDE. As long as <code>haml-lint</code> is included in your
+      project's <code>Gemfile</code>, the plugin will automatically annotate <code>.haml</code> files for you while you
+      have them open.
+    </p>
     ]]></description>
 
     <!-- Product and plugin compatibility requirements.


### PR DESCRIPTION
- adds installation/usage/contribution/license sections to readme
- adds some markup to the plugin description, as well as some notes on inspection

Closes #6