### PR TITLE
feat: ability to configure highlight severities

### DIFF
--- a/src/main/kotlin/me/benmelz/jetbrains/plugins/hamllint/HamlLintExternalAnnotator.kt
+++ b/src/main/kotlin/me/benmelz/jetbrains/plugins/hamllint/HamlLintExternalAnnotator.kt
@@ -4,6 +4,7 @@ import com.intellij.codeInspection.ex.Tools
 import com.intellij.lang.annotation.AnnotationHolder
 import com.intellij.lang.annotation.ExternalAnnotator
 import com.intellij.lang.annotation.HighlightSeverity
+import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.roots.ProjectFileIndex
 import com.intellij.openapi.util.TextRange
 import com.intellij.profile.codeInspection.InspectionProfileManager
@@ -15,6 +16,8 @@ import com.intellij.psi.PsiFile
  * @see ExternalAnnotator
  */
 class HamlLintExternalAnnotator : ExternalAnnotator<HamlLintExternalAnnotatorInfo, List<HamlLintOffense>>() {
+    private val logger = Logger.getInstance("HamlLint")
+
     /**
      * Collects `haml` code as a string as well as the path to the parent project of a file to lint.
      *
@@ -70,10 +73,13 @@ class HamlLintExternalAnnotator : ExternalAnnotator<HamlLintExternalAnnotatorInf
         severityMap: Map<String, HighlightSeverity>,
     ): HighlightSeverity? {
         val inspectionTool = inspectionProfileEntry(file)
-        val severityKey = if (severity == "error") {
-            inspectionTool.errorSeverityKey
-        } else {
-            inspectionTool.warningSeverityKey
+        val severityKey = when (severity) {
+            "warning" -> inspectionTool.warningSeverityKey
+            "error" -> inspectionTool.errorSeverityKey
+            else -> {
+                logger.error("Unrecognized severity: $severity")
+                null
+            }
         }
         return severityMap[severityKey]
     }

--- a/src/main/kotlin/me/benmelz/jetbrains/plugins/hamllint/HamlLintExternalAnnotator.kt
+++ b/src/main/kotlin/me/benmelz/jetbrains/plugins/hamllint/HamlLintExternalAnnotator.kt
@@ -16,6 +16,9 @@ import com.intellij.psi.PsiFile
  * @see ExternalAnnotator
  */
 class HamlLintExternalAnnotator : ExternalAnnotator<HamlLintExternalAnnotatorInfo, List<HamlLintOffense>>() {
+    /**
+     * The global logger instance for the plugin.
+     */
     private val logger = Logger.getInstance("HamlLint")
 
     /**
@@ -62,7 +65,7 @@ class HamlLintExternalAnnotator : ExternalAnnotator<HamlLintExternalAnnotatorInf
     }
 
     /**
-     * Translates a `haml-lint` severity to a [HighlightSeverity].
+     * Translates a `haml-lint` severity to a [HighlightSeverity] based on the inspection configuring.
      *
      * @param[severity] the `haml-lint` severity reported by an offense.
      * @return an equivalent [HighlightSeverity].
@@ -114,14 +117,31 @@ class HamlLintExternalAnnotator : ExternalAnnotator<HamlLintExternalAnnotatorInf
         return TextRange(startOffset, endOffset)
     }
 
+    /**
+     * Retrieves the top-level wrapper of a file's project's [HamlLintInspection].
+     *
+     * @param[file] the file whose inspection tool wrapper to retrieve.
+     * @return the top-level wrapper for the inspection tool.
+     */
     private fun inspectionTool(file: PsiFile): Tools {
         return InspectionProfileManager.getInstance(file.project).currentProfile.getTools("HamlLint", file.project)
     }
 
+    /**
+     * Retrieves a file's project's [HamlLintInspection] instance.
+     *
+     * @param[file] the file inspection instance to retrieve.
+     * @return the [HamlLintInspection] instance of the given file.
+     */
     private fun inspectionProfileEntry(file: PsiFile): HamlLintInspection {
         return inspectionTool(file).getInspectionTool(file).tool as HamlLintInspection
     }
 
+    /**
+     * Builds a mapping of all highlight severities by name.
+     *
+     * @return a mapping of highlight severities by name.
+     */
     private fun buildHighlightSeverityMap(): Map<String, HighlightSeverity> {
         return InspectionProfileManager.getInstance().severityRegistrar.allSeverities.associateBy { it.name }
     }

--- a/src/main/kotlin/me/benmelz/jetbrains/plugins/hamllint/HamlLintExternalAnnotator.kt
+++ b/src/main/kotlin/me/benmelz/jetbrains/plugins/hamllint/HamlLintExternalAnnotator.kt
@@ -3,7 +3,6 @@ package me.benmelz.jetbrains.plugins.hamllint
 import com.intellij.lang.annotation.AnnotationHolder
 import com.intellij.lang.annotation.ExternalAnnotator
 import com.intellij.lang.annotation.HighlightSeverity
-import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.roots.ProjectFileIndex
 import com.intellij.openapi.util.TextRange
 import com.intellij.profile.codeInspection.InspectionProfileManager
@@ -15,9 +14,6 @@ import com.intellij.psi.PsiFile
  * @see ExternalAnnotator
  */
 class HamlLintExternalAnnotator : ExternalAnnotator<HamlLintExternalAnnotatorInfo, List<HamlLintOffense>>() {
-
-    private val logger = Logger.getInstance("HamlLint")
-
     /**
      * Collects `haml` code as a string as well as the path to the parent project of a file to lint.
      *

--- a/src/main/kotlin/me/benmelz/jetbrains/plugins/hamllint/HamlLintExternalAnnotator.kt
+++ b/src/main/kotlin/me/benmelz/jetbrains/plugins/hamllint/HamlLintExternalAnnotator.kt
@@ -6,7 +6,7 @@ import com.intellij.lang.annotation.HighlightSeverity
 import com.intellij.openapi.editor.Document
 import com.intellij.openapi.roots.ProjectFileIndex
 import com.intellij.openapi.util.TextRange
-import com.intellij.profile.codeInspection.ProjectInspectionProfileManager
+import com.intellij.profile.codeInspection.InspectionProfileManager
 import com.intellij.psi.PsiFile
 
 /**
@@ -22,7 +22,7 @@ class HamlLintExternalAnnotator : ExternalAnnotator<HamlLintExternalAnnotatorInf
      * @return the necessary information to run `haml-lint` against a file, `null` if the file should be skipped.
      */
     override fun collectInformation(file: PsiFile): HamlLintExternalAnnotatorInfo? {
-        val inspectionProfile = ProjectInspectionProfileManager.getInstance(file.project).currentProfile
+        val inspectionProfile = InspectionProfileManager.getInstance(file.project).currentProfile
         val inspectionToolDisplayKey = inspectionProfile.getInspectionTool("HamlLint", file)?.displayKey
         if (!inspectionProfile.isToolEnabled(inspectionToolDisplayKey, file)) return null
         val fileText = file.viewProvider.document.charsSequence

--- a/src/main/kotlin/me/benmelz/jetbrains/plugins/hamllint/HamlLintInspection.kt
+++ b/src/main/kotlin/me/benmelz/jetbrains/plugins/hamllint/HamlLintInspection.kt
@@ -3,6 +3,12 @@ package me.benmelz.jetbrains.plugins.hamllint
 import com.intellij.codeInspection.ExternalAnnotatorInspectionVisitor
 import com.intellij.codeInspection.LocalInspectionTool
 import com.intellij.codeInspection.ProblemsHolder
+import com.intellij.codeInspection.options.OptPane
+import com.intellij.codeInspection.options.OptPane.dropdown
+import com.intellij.codeInspection.options.OptPane.option
+import com.intellij.codeInspection.options.OptPane.pane
+import com.intellij.lang.annotation.HighlightSeverity
+import com.intellij.profile.codeInspection.InspectionProfileManager
 import com.intellij.psi.PsiElementVisitor
 
 /**
@@ -13,7 +19,10 @@ import com.intellij.psi.PsiElementVisitor
  * @see LocalInspectionTool
  */
 class HamlLintInspection : LocalInspectionTool() {
-    /**
+    private var errorSeverityKey: String = HighlightSeverity.ERROR.name
+    private var warningSeverityKey: String = HighlightSeverity.WEAK_WARNING.name
+
+     /**
      * Delegates inspection logic to a [HamlLintExternalAnnotator].
      *
      * @param[holder] forwarded to an [ExternalAnnotatorInspectionVisitor].
@@ -30,4 +39,17 @@ class HamlLintInspection : LocalInspectionTool() {
      * @return false.
      */
     override fun showDefaultConfigurationOptions(): Boolean = false
+
+    override fun getOptionsPane(): OptPane {
+        val severityOptions = InspectionProfileManager
+            .getInstance()
+            .severityRegistrar
+            .allSeverities
+            .map { option(it.name, it.displayName) }
+            .toTypedArray()
+        return pane(
+            dropdown("errorSeverityKey", "Error:", *severityOptions),
+            dropdown("warningSeverityKey", "Warning:", *severityOptions),
+        )
+    }
 }

--- a/src/main/kotlin/me/benmelz/jetbrains/plugins/hamllint/HamlLintInspection.kt
+++ b/src/main/kotlin/me/benmelz/jetbrains/plugins/hamllint/HamlLintInspection.kt
@@ -4,9 +4,7 @@ import com.intellij.codeInspection.ExternalAnnotatorInspectionVisitor
 import com.intellij.codeInspection.LocalInspectionTool
 import com.intellij.codeInspection.ProblemsHolder
 import com.intellij.codeInspection.options.OptPane
-import com.intellij.codeInspection.options.OptPane.dropdown
-import com.intellij.codeInspection.options.OptPane.option
-import com.intellij.codeInspection.options.OptPane.pane
+import com.intellij.codeInspection.options.OptPane.*
 import com.intellij.lang.annotation.HighlightSeverity
 import com.intellij.psi.PsiElementVisitor
 
@@ -48,9 +46,10 @@ class HamlLintInspection : LocalInspectionTool() {
             ).map { option(it.name, it.displayCapitalizedName) }.toTypedArray(),
             option("","No highlighting"),
         )
-        return pane(
+        return pane(group(
+            "HamlLint Severities Mapping",
             dropdown("errorSeverityKey", "Error: ", *severityOptions),
             dropdown("warningSeverityKey", "Warning: ", *severityOptions),
-        )
+        ))
     }
 }

--- a/src/main/kotlin/me/benmelz/jetbrains/plugins/hamllint/HamlLintInspection.kt
+++ b/src/main/kotlin/me/benmelz/jetbrains/plugins/hamllint/HamlLintInspection.kt
@@ -19,7 +19,14 @@ import com.intellij.psi.PsiElementVisitor
  * @see LocalInspectionTool
  */
 class HamlLintInspection : LocalInspectionTool() {
+    /**
+     * The name of the highlight severity to use for `haml-lint` errors.
+     */
     var errorSeverityKey: String = HighlightSeverity.ERROR.name
+
+    /**
+     * The name of the highlight severity to use for `haml-lint` warnings.
+     */
     var warningSeverityKey: String = HighlightSeverity.WEAK_WARNING.name
 
      /**
@@ -40,6 +47,11 @@ class HamlLintInspection : LocalInspectionTool() {
      */
     override fun showDefaultConfigurationOptions(): Boolean = false
 
+    /**
+     * Builds the configuration pane for the inspection/plugin.
+     *
+     * @return a set of UI elements used to control the plugin and its settings.
+     */
     override fun getOptionsPane(): OptPane {
         val severityOptions = arrayOf(
             *arrayOf(

--- a/src/main/kotlin/me/benmelz/jetbrains/plugins/hamllint/HamlLintInspection.kt
+++ b/src/main/kotlin/me/benmelz/jetbrains/plugins/hamllint/HamlLintInspection.kt
@@ -4,7 +4,10 @@ import com.intellij.codeInspection.ExternalAnnotatorInspectionVisitor
 import com.intellij.codeInspection.LocalInspectionTool
 import com.intellij.codeInspection.ProblemsHolder
 import com.intellij.codeInspection.options.OptPane
-import com.intellij.codeInspection.options.OptPane.*
+import com.intellij.codeInspection.options.OptPane.dropdown
+import com.intellij.codeInspection.options.OptPane.group
+import com.intellij.codeInspection.options.OptPane.option
+import com.intellij.codeInspection.options.OptPane.pane
 import com.intellij.lang.annotation.HighlightSeverity
 import com.intellij.psi.PsiElementVisitor
 
@@ -44,12 +47,14 @@ class HamlLintInspection : LocalInspectionTool() {
                 HighlightSeverity.WARNING,
                 HighlightSeverity.WEAK_WARNING,
             ).map { option(it.name, it.displayCapitalizedName) }.toTypedArray(),
-            option("","No highlighting"),
+            option("", "No highlighting"),
         )
-        return pane(group(
-            "HamlLint Severities Mapping",
-            dropdown("errorSeverityKey", "Error: ", *severityOptions),
-            dropdown("warningSeverityKey", "Warning: ", *severityOptions),
-        ))
+        return pane(
+            group(
+                "HamlLint Severities Mapping",
+                dropdown("errorSeverityKey", "Error: ", *severityOptions),
+                dropdown("warningSeverityKey", "Warning: ", *severityOptions),
+            ),
+        )
     }
 }

--- a/src/main/kotlin/me/benmelz/jetbrains/plugins/hamllint/HamlLintInspection.kt
+++ b/src/main/kotlin/me/benmelz/jetbrains/plugins/hamllint/HamlLintInspection.kt
@@ -8,7 +8,6 @@ import com.intellij.codeInspection.options.OptPane.dropdown
 import com.intellij.codeInspection.options.OptPane.option
 import com.intellij.codeInspection.options.OptPane.pane
 import com.intellij.lang.annotation.HighlightSeverity
-import com.intellij.profile.codeInspection.InspectionProfileManager
 import com.intellij.psi.PsiElementVisitor
 
 /**
@@ -41,15 +40,17 @@ class HamlLintInspection : LocalInspectionTool() {
     override fun showDefaultConfigurationOptions(): Boolean = false
 
     override fun getOptionsPane(): OptPane {
-        val severityOptions = InspectionProfileManager
-            .getInstance()
-            .severityRegistrar
-            .allSeverities
-            .map { option(it.name, it.displayName) }
-            .toTypedArray()
+        val severityOptions = arrayOf(
+            *arrayOf(
+                HighlightSeverity.ERROR,
+                HighlightSeverity.WARNING,
+                HighlightSeverity.WEAK_WARNING,
+            ).map { option(it.name, it.displayCapitalizedName) }.toTypedArray(),
+            option("","No highlighting"),
+        )
         return pane(
-            dropdown("errorSeverityKey", "Error:", *severityOptions),
-            dropdown("warningSeverityKey", "Warning:", *severityOptions),
+            dropdown("errorSeverityKey", "Error: ", *severityOptions),
+            dropdown("warningSeverityKey", "Warning: ", *severityOptions),
         )
     }
 }

--- a/src/main/kotlin/me/benmelz/jetbrains/plugins/hamllint/HamlLintInspection.kt
+++ b/src/main/kotlin/me/benmelz/jetbrains/plugins/hamllint/HamlLintInspection.kt
@@ -29,7 +29,7 @@ class HamlLintInspection : LocalInspectionTool() {
      */
     var warningSeverityKey: String = HighlightSeverity.WEAK_WARNING.name
 
-     /**
+    /**
      * Delegates inspection logic to a [HamlLintExternalAnnotator].
      *
      * @param[holder] forwarded to an [ExternalAnnotatorInspectionVisitor].

--- a/src/main/kotlin/me/benmelz/jetbrains/plugins/hamllint/HamlLintInspection.kt
+++ b/src/main/kotlin/me/benmelz/jetbrains/plugins/hamllint/HamlLintInspection.kt
@@ -19,8 +19,8 @@ import com.intellij.psi.PsiElementVisitor
  * @see LocalInspectionTool
  */
 class HamlLintInspection : LocalInspectionTool() {
-    private var errorSeverityKey: String = HighlightSeverity.ERROR.name
-    private var warningSeverityKey: String = HighlightSeverity.WEAK_WARNING.name
+    var errorSeverityKey: String = HighlightSeverity.ERROR.name
+    var warningSeverityKey: String = HighlightSeverity.WEAK_WARNING.name
 
      /**
      * Delegates inspection logic to a [HamlLintExternalAnnotator].

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -15,15 +15,16 @@
          Guidelines: https://plugins.jetbrains.com/docs/marketplace/plugin-overview-page.html#plugin-description -->
     <description><![CDATA[
     <p>
-      Provides realtime inspection of <code><a href="https://github.com/sds/haml-lint">haml-lint</a></code> offenses.
+        Provides realtime inspection of <code><a href="https://github.com/sds/haml-lint">haml-lint</a></code> offenses.
     </p>
     <p>
-      No setup is necessary from the IDE. As long as <code>haml-lint</code> is included in your project's
-      <code>Gemfile</code>, the plugin will automatically annotate <code>.haml</code> files for you while you have
-      them open.
+        No setup is necessary from the IDE. As long as <code>haml-lint</code> is included in your project's
+        <code>Gemfile</code>, the plugin will automatically annotate <code>.haml</code> files for you while you have
+        them open.
     </p>
     <p>
-      The inspector can be turned on/off using the inspections menu (Haml -> HamlLint).
+        The inspector can be turned on/off and the severity mappings can be customized through the inspections menu
+        (<code>Haml</code> -> <code>HamlLint</code>).
     </p>
     ]]></description>
 

--- a/src/main/resources/inspectionDescriptions/HamlLint.html
+++ b/src/main/resources/inspectionDescriptions/HamlLint.html
@@ -1,6 +1,11 @@
-<html>
+<html lang="en">
 <body>
-Reports issues from the <a href="https://github.com/sds/haml-lint">HamlLint</a>. linter.
-Requires the haml-lint gem to be installed in the project SDK.
+<p>
+    Reports issues from the <a href="https://github.com/sds/haml-lint">HamlLint</a>. linter.
+    Requires the haml-lint gem to be installed in the project SDK.
+</p>
+<p>
+    Use the <em>HamlLint Severities Mapping</em> fields to customize the highlight levels.
+</p>
 </body>
 </html>


### PR DESCRIPTION
Closes #4 

- adds severity mapping options to the inspection profile
- uses inspection severity mappings to translate `haml-lint` severities to highlight severities