### PR TITLE
doc: fix mismatched parameter name

### DIFF
--- a/src/main/kotlin/me/benmelz/jetbrains/plugins/hamllint/HamlLintExternalAnnotator.kt
+++ b/src/main/kotlin/me/benmelz/jetbrains/plugins/hamllint/HamlLintExternalAnnotator.kt
@@ -102,7 +102,7 @@ class HamlLintExternalAnnotator : ExternalAnnotator<HamlLintExternalAnnotatorInf
      * Translates a line number of a `haml-lint` offense to a [TextRange] for highlighting.
      *
      * @param[lineNumber] the number of the line containing the offense.
-     * @param[document] the file that was linted.
+     * @param[file] the file that was linted.
      * @return a text range for the exact characters to highlight.
      */
     private fun translateOffenseLineNumber(lineNumber: Int, file: PsiFile): TextRange? {


### PR DESCRIPTION
`translateOffenseLineNumber` `document` parameter was renamed to `file` in #13, but the documentation wasn't updated correctly