### PR TITLE
chore: configure dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: gradle
+    directory: /
+    schedule:
+      interval: daily

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,4 +4,5 @@ updates:
     directory: /
     schedule:
       interval: daily
-    prefix: chore(deps)
+    commit-message:
+      prefix: chore(deps)

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,4 @@ updates:
     directory: /
     schedule:
       interval: daily
+    prefix: chore(deps)


### PR DESCRIPTION
configures dependabot on github to scan daily for gradle package updates