### PR TITLE
refactor: add configuration data class

### DIFF
--- a/src/main/kotlin/me/benmelz/jetbrains/plugins/hamllint/HamlLintConfiguration.kt
+++ b/src/main/kotlin/me/benmelz/jetbrains/plugins/hamllint/HamlLintConfiguration.kt
@@ -1,0 +1,14 @@
+package me.benmelz.jetbrains.plugins.hamllint
+
+/**
+ * Plugin configuration information collected from inspection settings.
+ *
+ * @property[enabled] whether or not inspection is enabled.
+ * @property[errorSeverityKey] The name of the highlight severity to use for errors.
+ * @property[warningSeverityKey] The name of the highlight severity to use for errors.
+ */
+data class HamlLintConfiguration(
+    val enabled: Boolean,
+    var errorSeverityKey: String,
+    var warningSeverityKey: String,
+)


### PR DESCRIPTION
rather than grab inspection data directly, wrap it all in a
configuration data class, allowing for better error handling and
expansion
