### PR TITLE
feat: custom execution commands

### DIFF
--- a/src/main/kotlin/me/benmelz/jetbrains/plugins/hamllint/HamlLint.kt
+++ b/src/main/kotlin/me/benmelz/jetbrains/plugins/hamllint/HamlLint.kt
@@ -13,14 +13,16 @@ import java.util.LinkedList
  *
  * @param[haml] the raw haml text to run against.
  * @param[workDirectory] the work directory from which to run haml-lint.
+ * @param[executionCommand] the execution command with which to run haml-lint.
  * @return a list of collected haml-lint offenses.
  */
 fun hamlLint(
     haml: CharSequence,
     workDirectory: Path,
+    executionCommand: List<String>,
 ): List<HamlLintOffense> {
     HamlLintTarget.createTempTarget(haml).use {
-        val cli = hamlLintCommandLine(it, workDirectory)
+        val cli = hamlLintCommandLine(it, workDirectory, executionCommand)
         return parseHamlLintOutput(ScriptRunnerUtil.getProcessOutput(cli))
     }
 }
@@ -31,14 +33,16 @@ fun hamlLint(
  *
  * @param[target] the [HamlLintTarget] to run against.
  * @param[workDirectory] the directory from which to run `haml-lint`.
+ * @param[executionCommand] the execution command with which to run haml-lint.
  * @return an executable [GeneralCommandLine].
  */
 private fun hamlLintCommandLine(
     target: HamlLintTarget,
     workDirectory: Path,
+    executionCommand: List<String>,
 ): GeneralCommandLine {
-    return GeneralCommandLine("bundle").apply {
-        this.addParameters("exec", "haml-lint", "--reporter", "json", target.absolutePath)
+    return GeneralCommandLine(executionCommand).apply {
+        this.addParameters("--reporter", "json", target.absolutePath)
         this.charset = StandardCharsets.UTF_8
         this.workDirectory = File(workDirectory.toUri())
         val rubocopConfigPath = workDirectory.resolve(".rubocop.yml").toAbsolutePath().toString()

--- a/src/main/kotlin/me/benmelz/jetbrains/plugins/hamllint/HamlLintConfiguration.kt
+++ b/src/main/kotlin/me/benmelz/jetbrains/plugins/hamllint/HamlLintConfiguration.kt
@@ -6,9 +6,11 @@ package me.benmelz.jetbrains.plugins.hamllint
  * @property[enabled] whether or not inspection is enabled.
  * @property[errorSeverityKey] The name of the highlight severity to use for errors.
  * @property[warningSeverityKey] The name of the highlight severity to use for errors.
+ * @property[executionCommand] The command to execute with.
  */
 data class HamlLintConfiguration(
     val enabled: Boolean,
     var errorSeverityKey: String,
     var warningSeverityKey: String,
+    var executionCommand: String,
 )

--- a/src/main/kotlin/me/benmelz/jetbrains/plugins/hamllint/HamlLintExternalAnnotator.kt
+++ b/src/main/kotlin/me/benmelz/jetbrains/plugins/hamllint/HamlLintExternalAnnotator.kt
@@ -91,6 +91,7 @@ class HamlLintExternalAnnotator : ExternalAnnotator<HamlLintExternalAnnotatorInf
             inspectionTool.isEnabled,
             inspectionProfileEntry.errorSeverityKey,
             inspectionProfileEntry.warningSeverityKey,
+            inspectionProfileEntry.executionCommand,
         )
     }
 

--- a/src/main/kotlin/me/benmelz/jetbrains/plugins/hamllint/HamlLintExternalAnnotator.kt
+++ b/src/main/kotlin/me/benmelz/jetbrains/plugins/hamllint/HamlLintExternalAnnotator.kt
@@ -28,11 +28,19 @@ class HamlLintExternalAnnotator : ExternalAnnotator<HamlLintExternalAnnotatorInf
      * @return the necessary information to run `haml-lint` against a file, `null` if the file should be skipped.
      */
     override fun collectInformation(file: PsiFile): HamlLintExternalAnnotatorInfo? {
-        if (!(getConfiguration(file).enabled)) return null
+        val configuration = getConfiguration(file)
+        if (!(configuration.enabled)) return null
+
         val fileText = file.viewProvider.document.charsSequence
+
         val contentRoot =
             ProjectFileIndex.getInstance(file.project).getContentRootForFile(file.virtualFile)?.toNioPath()
-        return if (contentRoot == null) null else HamlLintExternalAnnotatorInfo(fileText, contentRoot)
+        if (contentRoot == null) return null
+
+        val executionCommand = configuration.executionCommand.split(" ").filter { it.isNotEmpty() }
+        if (executionCommand.isEmpty()) return null
+
+        return HamlLintExternalAnnotatorInfo(fileText, contentRoot, executionCommand)
     }
 
     /**
@@ -46,7 +54,7 @@ class HamlLintExternalAnnotator : ExternalAnnotator<HamlLintExternalAnnotatorInf
             null
         } else {
             try {
-                hamlLint(collectedInfo.fileText, collectedInfo.contentRoot)
+                hamlLint(collectedInfo.fileText, collectedInfo.contentRoot, collectedInfo.executionCommand)
             } catch (e: ExecutionException) {
                 logger.error(e.message)
                 null

--- a/src/main/kotlin/me/benmelz/jetbrains/plugins/hamllint/HamlLintExternalAnnotatorInfo.kt
+++ b/src/main/kotlin/me/benmelz/jetbrains/plugins/hamllint/HamlLintExternalAnnotatorInfo.kt
@@ -7,8 +7,10 @@ import java.nio.file.Path
  *
  * @property[fileText] raw `haml` code to lint using `haml-lint`.
  * @property[contentRoot] the directory of the parent project of the code to be linted.
+ * @param[executionCommand] the execution command with which to run haml-lint.
  */
 data class HamlLintExternalAnnotatorInfo(
     val fileText: CharSequence,
     val contentRoot: Path,
+    val executionCommand: List<String>,
 )

--- a/src/main/kotlin/me/benmelz/jetbrains/plugins/hamllint/HamlLintInspection.kt
+++ b/src/main/kotlin/me/benmelz/jetbrains/plugins/hamllint/HamlLintInspection.kt
@@ -81,8 +81,8 @@ class HamlLintInspection : LocalInspectionTool() {
             separator(),
             group(
                 "Execution Command",
-                string("executionCommand", "", 32)
-            )
+                string("executionCommand", "", 32),
+            ),
         )
     }
 }

--- a/src/main/kotlin/me/benmelz/jetbrains/plugins/hamllint/HamlLintInspection.kt
+++ b/src/main/kotlin/me/benmelz/jetbrains/plugins/hamllint/HamlLintInspection.kt
@@ -8,6 +8,8 @@ import com.intellij.codeInspection.options.OptPane.dropdown
 import com.intellij.codeInspection.options.OptPane.group
 import com.intellij.codeInspection.options.OptPane.option
 import com.intellij.codeInspection.options.OptPane.pane
+import com.intellij.codeInspection.options.OptPane.separator
+import com.intellij.codeInspection.options.OptPane.string
 import com.intellij.lang.annotation.HighlightSeverity
 import com.intellij.psi.PsiElementVisitor
 
@@ -28,6 +30,11 @@ class HamlLintInspection : LocalInspectionTool() {
      * The name of the highlight severity to use for `haml-lint` warnings.
      */
     var warningSeverityKey: String = HighlightSeverity.WEAK_WARNING.name
+
+    /**
+     * The execution command with which to run `haml-lint`.
+     */
+    var executionCommand: String = "bundle exec haml-lint"
 
     /**
      * Delegates inspection logic to a [HamlLintExternalAnnotator].
@@ -67,10 +74,15 @@ class HamlLintInspection : LocalInspectionTool() {
             )
         return pane(
             group(
-                "HamlLint Severities Mapping",
+                "Severities Mapping",
                 dropdown("errorSeverityKey", "Error: ", *severityOptions),
                 dropdown("warningSeverityKey", "Warning: ", *severityOptions),
             ),
+            separator(),
+            group(
+                "Execution Command",
+                string("executionCommand", "", 32)
+            )
         )
     }
 }

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -18,13 +18,12 @@
         Provides realtime inspection of <code><a href="https://github.com/sds/haml-lint">haml-lint</a></code> offenses.
     </p>
     <p>
-        No setup is necessary from the IDE. As long as <code>haml-lint</code> is included in your project's
-        <code>Gemfile</code>, the plugin will automatically annotate <code>.haml</code> files for you while you have
-        them open.
+        The plugin will automatically attempt to annotate <code>.haml</code> files for you while you have them open.
     </p>
     <p>
-        The inspector can be turned on/off and the severity mappings can be customized through the inspections menu
-        (<code>Haml</code> -> <code>HamlLint</code>).
+        Configuration options can be set in the inspections menu (<code>Haml</code> -> <code>HamlLint</code>). From
+        there the inspector can be turned on/off, highlighting styles can be set, as well as custom execution commands
+        for projects that needs it (e.g. you are not using bundler, are using docker, etc).
     </p>
     ]]></description>
 

--- a/src/main/resources/inspectionDescriptions/HamlLint.html
+++ b/src/main/resources/inspectionDescriptions/HamlLint.html
@@ -5,7 +5,10 @@
     Requires the haml-lint gem to be installed in the project SDK.
 </p>
 <p>
-    Use the <em>HamlLint Severities Mapping</em> fields to customize the highlight levels.
+    Use the <em>Severities Mapping</em> fields to customize the highlight levels.
+</p>
+<p>
+    Use the <em>Execution Command</em> field to customize how <code>haml-lint</code> will be invoked.
 </p>
 </body>
 </html>

--- a/src/test/kotlin/me/benmelz/jetbrains/plugins/hamllint/HamlLintTest.kt
+++ b/src/test/kotlin/me/benmelz/jetbrains/plugins/hamllint/HamlLintTest.kt
@@ -16,7 +16,7 @@ internal class HamlLintTest {
                 ScriptRunnerUtil.getProcessOutput(any())
             }.thenReturn(hamlLintOutputJson)
 
-            val offenses = hamlLint("test haml", Path.of("/"))
+            val offenses = hamlLint("test haml", Path.of("/"), listOf("bundle", "exec", "haml-lint"))
             assertEquals(offenses.size, 3)
             assertEquals(offenses[0], HamlLintOffense(0, "warning", "TestOffense0", "test offense 0"))
             assertEquals(offenses[1], HamlLintOffense(1, "warning", "TestOffense1", "test offense 1"))


### PR DESCRIPTION
adds the ability to set a custom execution commands so that the plugin can be used without `bundler` or with tools like `docker`

Closes #50 