### PR TITLE
fix: expand compatibility range

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -49,7 +49,7 @@ tasks {
 
     patchPluginXml {
         sinceBuild.set("231")
-        untilBuild.set("232.*")
+        untilBuild.set("233.*")
     }
 
     signPlugin {


### PR DESCRIPTION
expands the compatibility range for the plugin from `232.*` to `233.*`
